### PR TITLE
[FEAT] 부품 주문 API 연동

### DIFF
--- a/src/layouts/Navigation/Navigation.module.scss
+++ b/src/layouts/Navigation/Navigation.module.scss
@@ -54,3 +54,21 @@
     margin-top: 300px;
   }
 }
+
+.orderCount {
+  margin-left: 11px;
+
+  width: 30px;
+  height: 30px;
+  border-radius: 20px;
+  background-color: rgba(249, 60, 101);
+
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+
+  @include Body1;
+  color: $white;
+  font-size: 16px;
+}

--- a/src/layouts/Navigation/index.tsx
+++ b/src/layouts/Navigation/index.tsx
@@ -1,12 +1,15 @@
 import { Link, useLocation } from 'react-router-dom';
+import { useRecoilValue } from 'recoil';
 
 import Logo from '@/assets/logo/logo.webp';
 import { NAVIGATION_MENU_LIST } from '@/constants/navigationMenuList';
+import { orderCountState } from '@/recoil/orderCountState';
 
 import styles from './Navigation.module.scss';
 
 export const Navigation = () => {
   const location = useLocation();
+  const orderCount = useRecoilValue(orderCountState);
 
   return (
     <nav className={styles.container}>
@@ -19,6 +22,7 @@ export const Navigation = () => {
             <li className={location.pathname.startsWith(menu.path) ? styles.active : ''}>
               <img className={styles.icon} src={menu.icon} alt={menu.title} />
               <span>{menu.title}</span>
+              {menu.title === '부품주문' && <div className={styles.orderCount}>{orderCount}</div>}
             </li>
           </Link>
         ))}

--- a/src/layouts/Navigation/index.tsx
+++ b/src/layouts/Navigation/index.tsx
@@ -1,15 +1,14 @@
 import { Link, useLocation } from 'react-router-dom';
-import { useRecoilValue } from 'recoil';
 
 import Logo from '@/assets/logo/logo.webp';
 import { NAVIGATION_MENU_LIST } from '@/constants/navigationMenuList';
-import { orderCountState } from '@/recoil/orderCountState';
+import { getOrderCount } from '@/utils/orderCount';
 
 import styles from './Navigation.module.scss';
 
 export const Navigation = () => {
   const location = useLocation();
-  const orderCount = useRecoilValue(orderCountState);
+  const count = getOrderCount();
 
   return (
     <nav className={styles.container}>
@@ -22,7 +21,7 @@ export const Navigation = () => {
             <li className={location.pathname.startsWith(menu.path) ? styles.active : ''}>
               <img className={styles.icon} src={menu.icon} alt={menu.title} />
               <span>{menu.title}</span>
-              {menu.title === '부품주문' && <div className={styles.orderCount}>{orderCount}</div>}
+              {menu.title === '부품주문' && <div className={styles.orderCount}>{count}</div>}
             </li>
           </Link>
         ))}

--- a/src/pages/Order/OrderDetail.tsx
+++ b/src/pages/Order/OrderDetail.tsx
@@ -1,6 +1,12 @@
+import { useEffect, useState } from 'react';
+
+import { useQuery } from 'react-query';
 import { useParams } from 'react-router-dom';
 
 import RightChevron from '@/assets/icons/rightChevron.svg';
+import { USER_ID } from '@/services';
+import { getDronePart } from '@/services/orderApi';
+import { DronePartDetailData } from '@/types';
 
 import styles from './OrderDetail.module.scss';
 import DroneDetailItem from './atoms/DroneDetailItem';
@@ -9,15 +15,28 @@ const OrderDetail = () => {
   const { droneId } = useParams();
   const numDroneId = Number(droneId);
 
+  const [droneData, setDroneData] = useState<DronePartDetailData>();
+
+  const { data } = useQuery({
+    queryKey: ['ORDER_PARTS', 'ALL', USER_ID, numDroneId],
+    queryFn: () => getDronePart(USER_ID, numDroneId),
+  });
+
+  useEffect(() => {
+    if (data) {
+      setDroneData(data.orderParts);
+    }
+  }, [data]);
+
   return (
     <div className={styles.container}>
       <div className={styles.subHeader}>
         <span>부품 주문</span>
         <img src={RightChevron} alt="left-chevron" />
-        <span>드론이름</span> {/* API 연결할 때 드론 데이터 받아오면 이름으로 변경 예정*/}
+        <span>드론이름</span>
       </div>
-      <div className={styles.header}>드론이름</div>
-      <DroneDetailItem droneId={numDroneId} />
+      <div className={styles.header}>{droneData?.nickname}</div>
+      <DroneDetailItem drone={droneData!} />
     </div>
   );
 };

--- a/src/pages/Order/OrderDetail.tsx
+++ b/src/pages/Order/OrderDetail.tsx
@@ -1,69 +1,13 @@
-//import { useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
-import DroneImg from '@/assets/icons/droneImg.svg';
 import RightChevron from '@/assets/icons/rightChevron.svg';
-import DummyPart1 from '@/assets/part1.png';
-import DummyPart2 from '@/assets/part2.png';
-import DummyPart3 from '@/assets/part3.png';
-import { DronePartDetailData } from '@/types';
 
 import styles from './OrderDetail.module.scss';
 import DroneDetailItem from './atoms/DroneDetailItem';
 
 const OrderDetail = () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  //const { droneId } = useParams();
-
-  // API 연결할 때 상세 화면에서 새로 호출 -> 이전 화면에서 받아올 필요 x
-  // 일단 더미 데이터로 구현
-  const Dummy: DronePartDetailData = {
-    img: DroneImg,
-    name: 'Test 1',
-    id: 0,
-    orderDate: '2024년 1월 1일',
-    currentPart: [
-      {
-        블레이드: [
-          { name: '구동부1', score: 56 },
-          { name: '구동부2', score: 58 },
-        ],
-      },
-      { 모터: [{ name: '구동부4', score: 58 }] },
-      { ESC: [{ name: '구동부2', score: 58 }] },
-    ],
-    salePart: [
-      {
-        블레이드: {
-          img: DummyPart1,
-          arrivalDate: '2024년 1월 28일',
-          detail: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-          salePrice: 8800,
-          wefloPrice: 7500,
-          num: 2,
-        },
-      },
-      {
-        모터: {
-          img: DummyPart2,
-          arrivalDate: '2024년 1월 29일',
-          detail: '13T 드론 브러시리스 모터 멀티 쿼드 RC A2212 1000KV',
-          salePrice: 8800,
-          wefloPrice: 7500,
-          num: 1,
-        },
-      },
-      {
-        ESC: {
-          img: DummyPart3,
-          arrivalDate: '2024년 1월 28일',
-          detail: 'DJI Agras 드론 ESC 모듈 T30 T10 T40 T20P',
-          salePrice: 8800,
-          wefloPrice: 7500,
-          num: 1,
-        },
-      },
-    ],
-  };
+  const { droneId } = useParams();
+  const numDroneId = Number(droneId);
 
   return (
     <div className={styles.container}>
@@ -73,7 +17,7 @@ const OrderDetail = () => {
         <span>드론이름</span> {/* API 연결할 때 드론 데이터 받아오면 이름으로 변경 예정*/}
       </div>
       <div className={styles.header}>드론이름</div>
-      <DroneDetailItem drone={Dummy} />
+      <DroneDetailItem droneId={numDroneId} />
     </div>
   );
 };

--- a/src/pages/Order/atoms/DroneDetailItem.module.scss
+++ b/src/pages/Order/atoms/DroneDetailItem.module.scss
@@ -85,6 +85,7 @@
       .partDetail {
         display: flex;
         flex-direction: column;
+        gap: 7px;
 
         @include H4;
         font-weight: 500;

--- a/src/pages/Order/atoms/DroneDetailItem.tsx
+++ b/src/pages/Order/atoms/DroneDetailItem.tsx
@@ -1,53 +1,33 @@
-import { useEffect, useState } from 'react';
-
-import { useQuery } from 'react-query';
-import { useParams } from 'react-router-dom';
-
-import { USER_ID } from '@/services';
-import { getDronePart } from '@/services/orderApi';
 import { DronePartDetailData } from '@/types';
 
 import styles from './DroneDetailItem.module.scss';
 import PartOnSale from './PartOnSale';
 
 interface DroneDetailItemProps {
-  droneId: number;
+  drone: DronePartDetailData;
 }
 
-const DroneDetailItem = ({ droneId }: DroneDetailItemProps) => {
-  const [droneData, setDroneData] = useState<DronePartDetailData>();
-
-  const { data } = useQuery({
-    queryKey: ['ORDER_PARTS', 'ALL', USER_ID, droneId],
-    queryFn: () => getDronePart(USER_ID, droneId),
-  });
-
-  useEffect(() => {
-    if (data) {
-      setDroneData(data.orderParts);
-    }
-  }, [data]);
-
+const DroneDetailItem = ({ drone }: DroneDetailItemProps) => {
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <div className={styles.imgContainer}>
-          <img src={droneData?.droneImg} alt="드론 이미지" />
+          <img src={drone?.droneImg} alt="드론 이미지" />
         </div>
         <div className={styles.profile}>
           <div className={styles.infoContainer}>
             <div className={styles.info}>
               <div className={styles.label}>제품명</div>
-              <div className={styles.value}>{droneData?.nickname}</div>
+              <div className={styles.value}>{drone?.nickname}</div>
             </div>
             <div className={styles.info}>
               <div className={styles.label}>주문일</div>
-              <div className={styles.value}>{droneData?.orderDate}</div>
+              <div className={styles.value}>{drone?.orderDate}</div>
             </div>
           </div>
           <div className={styles.partInfo}>
-            {droneData?.abnormalities.map((data, index) => {
-              const isLast = index === droneData.abnormalities.length - 1;
+            {drone?.abnormalities.map((data, index) => {
+              const isLast = index === drone.abnormalities.length - 1;
               return (
                 <div
                   className={`${styles.partContainer} ${isLast && styles.lastContainer}`}
@@ -70,7 +50,7 @@ const DroneDetailItem = ({ droneId }: DroneDetailItemProps) => {
         </div>
       </div>
       <div className={styles.content}>
-        {droneData?.productsInfo.map((part, index) => {
+        {drone?.productsInfo.map((part, index) => {
           return <PartOnSale part={part} key={index} />;
         })}
       </div>

--- a/src/pages/Order/atoms/DroneDetailItem.tsx
+++ b/src/pages/Order/atoms/DroneDetailItem.tsx
@@ -45,15 +45,15 @@ const DroneDetailItem = ({ drone }: DroneDetailItemProps) => {
                   key={index}
                 >
                   <div className={styles.partKind}>{data.category}</div>
-                  {data.partsScore.map((t, index) => {
-                    return (
-                      <div className={styles.partDetail} key={index}>
-                        <div>
+                  <div className={styles.partDetail}>
+                    {data.partsScore.map((t, index) => {
+                      return (
+                        <div key={index}>
                           {t.name} ({t.score}점)
                         </div>
-                      </div>
-                    );
-                  })}
+                      );
+                    })}
+                  </div>
                 </div>
               );
             })}

--- a/src/pages/Order/atoms/DroneDetailItem.tsx
+++ b/src/pages/Order/atoms/DroneDetailItem.tsx
@@ -8,6 +8,17 @@ interface DroneDetailItemProps {
 }
 
 const DroneDetailItem = ({ drone }: DroneDetailItemProps) => {
+  const formatDate = (stringDate: string) => {
+    const d = new Date(stringDate);
+    const date = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(d);
+
+    return date;
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
@@ -22,7 +33,7 @@ const DroneDetailItem = ({ drone }: DroneDetailItemProps) => {
             </div>
             <div className={styles.info}>
               <div className={styles.label}>주문일</div>
-              <div className={styles.value}>{drone?.orderDate}</div>
+              <div className={styles.value}>{drone?.orderDate && formatDate(drone?.orderDate)}</div>
             </div>
           </div>
           <div className={styles.partInfo}>

--- a/src/pages/Order/atoms/DroneDetailItem.tsx
+++ b/src/pages/Order/atoms/DroneDetailItem.tsx
@@ -1,61 +1,76 @@
+import { useEffect, useState } from 'react';
+
+import { useQuery } from 'react-query';
+import { useParams } from 'react-router-dom';
+
+import { USER_ID } from '@/services';
+import { getDronePart } from '@/services/orderApi';
 import { DronePartDetailData } from '@/types';
 
 import styles from './DroneDetailItem.module.scss';
 import PartOnSale from './PartOnSale';
 
 interface DroneDetailItemProps {
-  drone: DronePartDetailData;
+  droneId: number;
 }
-const DroneDetailItem = ({ drone }: DroneDetailItemProps) => {
+
+const DroneDetailItem = ({ droneId }: DroneDetailItemProps) => {
+  const [droneData, setDroneData] = useState<DronePartDetailData>();
+
+  const { data } = useQuery({
+    queryKey: ['ORDER_PARTS', 'ALL', USER_ID, droneId],
+    queryFn: () => getDronePart(USER_ID, droneId),
+  });
+
+  useEffect(() => {
+    if (data) {
+      setDroneData(data.orderParts);
+    }
+  }, [data]);
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
         <div className={styles.imgContainer}>
-          <img src={drone.img} alt="드론 이미지" />
+          <img src={droneData?.droneImg} alt="드론 이미지" />
         </div>
         <div className={styles.profile}>
           <div className={styles.infoContainer}>
             <div className={styles.info}>
               <div className={styles.label}>제품명</div>
-              <div className={styles.value}>{drone.name}</div>
+              <div className={styles.value}>{droneData?.nickname}</div>
             </div>
             <div className={styles.info}>
               <div className={styles.label}>주문일</div>
-              <div className={styles.value}>{drone.orderDate}</div>
+              <div className={styles.value}>{droneData?.orderDate}</div>
             </div>
           </div>
           <div className={styles.partInfo}>
-            {drone.currentPart.map((part, index) => {
-              const isLast = index === Object(drone.currentPart).length - 1;
+            {droneData?.abnormalities.map((data, index) => {
+              const isLast = index === droneData.abnormalities.length - 1;
               return (
-                <>
-                  {Object.entries(part).map(([kind, details], index) => {
+                <div
+                  className={`${styles.partContainer} ${isLast && styles.lastContainer}`}
+                  key={index}
+                >
+                  <div className={styles.partKind}>{data.category}</div>
+                  {data.partsScore.map((t, index) => {
                     return (
-                      <div
-                        className={`${styles.partContainer} ${isLast && styles.lastContainer}`}
-                        key={index}
-                      >
-                        <div className={styles.partKind}>{kind}</div>
-                        {details.map((detail, index) => {
-                          return (
-                            <div className={styles.partDetail} key={index}>
-                              <div>
-                                {detail.name} ({detail.score}점)
-                              </div>
-                            </div>
-                          );
-                        })}
+                      <div className={styles.partDetail} key={index}>
+                        <div>
+                          {t.name} ({t.score}점)
+                        </div>
                       </div>
                     );
                   })}
-                </>
+                </div>
               );
             })}
           </div>
         </div>
       </div>
       <div className={styles.content}>
-        {drone.salePart.map((part, index) => {
+        {droneData?.productsInfo.map((part, index) => {
           return <PartOnSale part={part} key={index} />;
         })}
       </div>

--- a/src/pages/Order/atoms/DroneItem.module.scss
+++ b/src/pages/Order/atoms/DroneItem.module.scss
@@ -23,6 +23,10 @@
   @include H1;
   font-size: 23.975px;
   color: $main-5;
+
+  .droneImg {
+    border-radius: 9px;
+  }
 }
 
 .scoreContainer {
@@ -70,9 +74,6 @@
 
     .tableHeader {
       // background-color: #fafafb;
-      border: 0.6px solid $gray-2;
-      border-radius: 9px 9px 0px 0px;
-      background-color: $gray-1;
 
       color: $main-5;
       font-family: Pretendard;
@@ -81,10 +82,27 @@
 
       :first-child {
         padding: 10px 0px 10px 59px;
+        border: 0.6px solid $gray-2;
+        border-radius: 9px 0px 0px 0px;
+        border-right: none;
+        background-color: $gray-1;
+      }
+
+      :nth-child(2),
+      :nth-child(3) {
+        padding: 10px 0px 10px 0px;
+        border: 0.6px solid $gray-2;
+        border-right: none;
+        border-left: none;
+        background-color: $gray-1;
       }
 
       :last-child {
         padding: 10px 108px 10px 0px;
+        border: 0.6px solid $gray-2;
+        border-radius: 0px 9px 0px 0px;
+        border-left: none;
+        background-color: $gray-1;
       }
 
       .thNotCenter {

--- a/src/pages/Order/atoms/DroneItem.tsx
+++ b/src/pages/Order/atoms/DroneItem.tsx
@@ -28,7 +28,7 @@ const DroneItem = ({ drone }: DroneItemProps) => {
     <div className={styles.container} key={drone.nickname}>
       <div className={styles.droneHeader}>
         <div className={styles.droneProfile}>
-          <img src={drone.droneImg} alt="드론 이미지" />
+          <img className={styles.droneImg} src={drone.droneImg} alt="드론 이미지" />
           <div>{drone.nickname}</div>
         </div>
         <div className={styles.scoreContainer}>

--- a/src/pages/Order/atoms/DroneItem.tsx
+++ b/src/pages/Order/atoms/DroneItem.tsx
@@ -62,9 +62,9 @@ const DroneItem = ({ drone }: DroneItemProps) => {
               return (
                 <tr key={t.category} className={styles.tableContent}>
                   {Object.values(t).map((v, key) => {
-                    const isCenter = key === 5 || key === 6;
+                    const isCenter = key === 6 || key === 7;
 
-                    if (key === 0 || key === 3 || key === 4) {
+                    if (key === 0 || key === 1 || key === 4 || key === 5) {
                       return;
                     }
 

--- a/src/pages/Order/atoms/DroneItem.tsx
+++ b/src/pages/Order/atoms/DroneItem.tsx
@@ -25,11 +25,11 @@ const DroneItem = ({ drone }: DroneItemProps) => {
   };
 
   return (
-    <div className={styles.container} key={drone.name}>
+    <div className={styles.container} key={drone.nickname}>
       <div className={styles.droneHeader}>
         <div className={styles.droneProfile}>
-          <img src={drone.img} alt="드론 이미지" />
-          <div>{drone.name}</div>
+          <img src={drone.droneImg} alt="드론 이미지" />
+          <div>{drone.nickname}</div>
         </div>
         <div className={styles.scoreContainer}>
           <div className={styles.score}>
@@ -58,16 +58,20 @@ const DroneItem = ({ drone }: DroneItemProps) => {
             </tr>
           </thead>
           <tbody>
-            {drone.dronePart.map((t) => {
+            {drone.productsInfo.map((t) => {
               return (
-                <tr key={t.kind} className={styles.tableContent}>
+                <tr key={t.category} className={styles.tableContent}>
                   {Object.values(t).map((v, key) => {
-                    const isCenter = key === 2 || key === 3;
+                    const isCenter = key === 5 || key === 6;
+
+                    if (key === 0 || key === 3 || key === 4) {
+                      return;
+                    }
 
                     // 천 원 단위로 콤마 추가
                     let price = '';
-                    const isPrice = key === 2;
-                    if (key === 2 && typeof v === 'number') {
+                    const isPrice = key === 5;
+                    if (isPrice && typeof v === 'number') {
                       price = addComma(v);
                     }
 

--- a/src/pages/Order/atoms/PartOnSale.tsx
+++ b/src/pages/Order/atoms/PartOnSale.tsx
@@ -13,36 +13,30 @@ const PartOnSale = ({ part }: PartOnSaleProps) => {
   };
 
   return (
-    <>
-      {Object.entries(part).map(([kind, content], index) => {
-        return (
-          <div className={styles.container} key={index}>
-            <div className={styles.header}>
-              <div className={styles.date}>{content.arrivalDate} 도착 예정</div>
-              <img src={content.img} alt="드론 부품 이미지" className={styles.partImg} />
-              <div className={styles.content}>
-                <div className={styles.partName}>{kind}</div>
-                <div className={styles.partDetail}>{content.detail}</div>
-              </div>
-            </div>
-            <div className={styles.price}>
-              <div className={styles.salePrice}>
-                <div className={styles.label}>시장가</div>
-                <div className={styles.value}>
-                  <div className={styles.text}>{addComma(content.salePrice)}원</div>
-                  <img className={styles.saleImg} src={priceSale} alt="세일 표시" />
-                </div>
-              </div>
-              <div className={styles.wefloPrice}>
-                <div className={styles.label}>위플로 가격</div>
-                <div className={styles.value}>{addComma(content.wefloPrice)}원</div>
-                <div className={styles.num}>({content.num}개)</div>
-              </div>
-            </div>
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <div className={styles.date}>{part.amount} 도착 예정</div>
+        <img src={part.productImage} alt="드론 부품 이미지" className={styles.partImg} />
+        <div className={styles.content}>
+          <div className={styles.partName}>{part.category}</div>
+          <div className={styles.partDetail}>{part.name}</div>
+        </div>
+      </div>
+      <div className={styles.price}>
+        <div className={styles.salePrice}>
+          <div className={styles.label}>시장가</div>
+          <div className={styles.value}>
+            <div className={styles.text}>{addComma(part.price)}원</div>
+            <img className={styles.saleImg} src={priceSale} alt="세일 표시" />
           </div>
-        );
-      })}
-    </>
+        </div>
+        <div className={styles.wefloPrice}>
+          <div className={styles.label}>위플로 가격</div>
+          <div className={styles.value}>{addComma(part.salePrice)}원</div>
+          <div className={styles.num}>({part.amount}개)</div>
+        </div>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/Order/atoms/PartOnSale.tsx
+++ b/src/pages/Order/atoms/PartOnSale.tsx
@@ -12,10 +12,21 @@ const PartOnSale = ({ part }: PartOnSaleProps) => {
     return returnString;
   };
 
+  const formatDate = (stringDate: string) => {
+    const d = new Date(stringDate);
+    const date = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    }).format(d);
+
+    return date;
+  };
+
   return (
     <div className={styles.container}>
       <div className={styles.header}>
-        <div className={styles.date}>{part.amount} 도착 예정</div>
+        <div className={styles.date}>{formatDate(part.estimateDate)} 도착 예정</div>
         <img src={part.productImage} alt="드론 부품 이미지" className={styles.partImg} />
         <div className={styles.content}>
           <div className={styles.partName}>{part.category}</div>

--- a/src/pages/Order/index.tsx
+++ b/src/pages/Order/index.tsx
@@ -2,21 +2,18 @@ import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 import { Outlet } from 'react-router-dom';
-import { useSetRecoilState } from 'recoil';
 
 import FloatingBtn from '@/assets/icons/floatingBtn.svg';
 import { USER_ID } from '@/services';
 import { getAllParts } from '@/services/orderApi';
 import { DronePartData } from '@/types';
-
-import { orderCountState } from '../../recoil/orderCountState';
+import { setOrderCount } from '@/utils/orderCount';
 
 import styles from './Order.module.scss';
 import DroneItem from './atoms/DroneItem';
 
 const Order = () => {
   const [allOrders, setAllOrders] = useState<DronePartData[]>();
-  const setOrderCount = useSetRecoilState(orderCountState);
 
   const { data } = useQuery({
     queryKey: ['ORDER_PARTS', 'ALL', USER_ID],

--- a/src/pages/Order/index.tsx
+++ b/src/pages/Order/index.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 import { Outlet } from 'react-router-dom';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import FloatingBtn from '@/assets/icons/floatingBtn.svg';
 import { USER_ID } from '@/services';
@@ -16,7 +16,7 @@ import DroneItem from './atoms/DroneItem';
 
 const Order = () => {
   const [allOrders, setAllOrders] = useState<DronePartData[]>();
-  const [orderCount, setOrderCount] = useRecoilState(orderCountState);
+  const setOrderCount = useSetRecoilState(orderCountState);
 
   const { data } = useQuery({
     queryKey: ['ORDER_PARTS', 'ALL', USER_ID],

--- a/src/pages/Order/index.tsx
+++ b/src/pages/Order/index.tsx
@@ -1,69 +1,29 @@
+import { useEffect, useState } from 'react';
+
+import { useQuery } from 'react-query';
 import { Outlet } from 'react-router-dom';
 
-import DroneImg from '@/assets/icons/droneImg.svg';
 import FloatingBtn from '@/assets/icons/floatingBtn.svg';
+import { USER_ID } from '@/services';
+import { getAllParts } from '@/services/orderApi';
 import { DronePartData } from '@/types';
 
 import styles from './Order.module.scss';
 import DroneItem from './atoms/DroneItem';
 
 const Order = () => {
-  const Dummy: DronePartData[] = [
-    {
-      img: DroneImg,
-      name: 'Test 1',
-      id: 0,
-      balanceScore: 70,
-      totalScore: 100,
-      dronePart: [
-        {
-          kind: '블레이드',
-          detail: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-          price: 8800,
-          num: 1,
-        },
-        {
-          kind: '모터',
-          detail: '13T 드론 브러시리스 모터 멀티 쿼드 RC A2212 1000KV',
-          price: 15830,
-          num: 1,
-        },
-        {
-          kind: 'ESC',
-          detail: 'DJI Agras 드론 ESC 모듈 T30 T10 T40 T20P',
-          price: 174300,
-          num: 2,
-        },
-      ],
-    },
-    {
-      img: DroneImg,
-      name: 'Test 1',
-      id: 1,
-      balanceScore: 70,
-      totalScore: 100,
-      dronePart: [
-        {
-          kind: '블레이드',
-          detail: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-          price: 8800,
-          num: 1,
-        },
-        {
-          kind: '모터',
-          detail: '13T 드론 브러시리스 모터 멀티 쿼드 RC A2212 1000KV',
-          price: 15830,
-          num: 1,
-        },
-        {
-          kind: 'ESC',
-          detail: 'DJI Agras 드론 ESC 모듈 T30 T10 T40 T20P',
-          price: 174300,
-          num: 2,
-        },
-      ],
-    },
-  ];
+  const [allOrders, setAllOrders] = useState<DronePartData[]>();
+
+  const { data } = useQuery({
+    queryKey: ['ORDER_PARTS', 'ALL', USER_ID],
+    queryFn: () => getAllParts(USER_ID),
+  });
+
+  useEffect(() => {
+    if (data) {
+      setAllOrders(data.orderParts);
+    }
+  }, [data]);
 
   return (
     <div className={styles.container}>
@@ -72,9 +32,10 @@ const Order = () => {
       </div>
       <div className={styles.header}>부품 주문</div>
       <div className={styles.content}>
-        {Dummy.map((data) => {
-          return <DroneItem key={data.id} drone={data} />;
-        })}
+        {allOrders &&
+          allOrders.map((data) => {
+            return <DroneItem key={data.id} drone={data} />;
+          })}
       </div>
       <div className={styles.floatingBtnContainer}>
         <button type="button" className={styles.floatingBtn}>

--- a/src/pages/Order/index.tsx
+++ b/src/pages/Order/index.tsx
@@ -2,17 +2,21 @@ import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 import { Outlet } from 'react-router-dom';
+import { useRecoilState } from 'recoil';
 
 import FloatingBtn from '@/assets/icons/floatingBtn.svg';
 import { USER_ID } from '@/services';
 import { getAllParts } from '@/services/orderApi';
 import { DronePartData } from '@/types';
 
+import { orderCountState } from '../../recoil/orderCountState';
+
 import styles from './Order.module.scss';
 import DroneItem from './atoms/DroneItem';
 
 const Order = () => {
   const [allOrders, setAllOrders] = useState<DronePartData[]>();
+  const [orderCount, setOrderCount] = useRecoilState(orderCountState);
 
   const { data } = useQuery({
     queryKey: ['ORDER_PARTS', 'ALL', USER_ID],
@@ -22,6 +26,7 @@ const Order = () => {
   useEffect(() => {
     if (data) {
       setAllOrders(data.orderParts);
+      setOrderCount(data.totalOrderCount);
     }
   }, [data]);
 

--- a/src/recoil/orderCountState.ts
+++ b/src/recoil/orderCountState.ts
@@ -1,0 +1,6 @@
+import { atom } from 'recoil';
+
+export const orderCountState = atom({
+  key: 'orderCountState',
+  default: 0,
+});

--- a/src/recoil/orderCountState.ts
+++ b/src/recoil/orderCountState.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const orderCountState = atom({
-  key: 'orderCountState',
-  default: 0,
-});

--- a/src/services/orderApi.ts
+++ b/src/services/orderApi.ts
@@ -10,3 +10,14 @@ export const getAllParts = async (userId: number) => {
   const data = await res.json();
   return data.data;
 };
+
+export const getDronePart = async (userId: number, droneId: number) => {
+  const res = await fetch(`${BASE_URL}/api/orders/${userId}/${droneId}`);
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch drone part data');
+  }
+
+  const data = await res.json();
+  return data.data;
+};

--- a/src/services/orderApi.ts
+++ b/src/services/orderApi.ts
@@ -1,0 +1,12 @@
+import { BASE_URL } from '.';
+
+export const getAllParts = async (userId: number) => {
+  const res = await fetch(`${BASE_URL}/api/orders/${userId}`);
+
+  if (!res.ok) {
+    throw new Error('Failed to fetch order data');
+  }
+
+  const data = await res.json();
+  return data.data;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -59,26 +59,28 @@ export interface DronePartData {
 }
 
 export interface PartOnSaleData {
-  [kind: string]: {
-    img: string;
-    detail: string;
-    salePrice: number;
-    wefloPrice: number;
-    num: number;
-    arrivalDate: string;
-  };
+  productImage: string;
+  category: string;
+  name: string;
+  price: number;
+  salePrice: number;
+  totalPrice: number;
+  amount: number;
+}
+
+interface Abnormality {
+  category: string;
+  partsScore: {
+    name: string;
+    score: number;
+  }[];
 }
 
 export interface DronePartDetailData {
-  img: string;
-  name: string;
   id: number;
+  droneImg: string;
+  nickname: string;
   orderDate: string;
-  currentPart: {
-    [kind: string]: {
-      name: string;
-      score: number;
-    }[];
-  }[];
-  salePart: PartOnSaleData[];
+  productsInfo: PartOnSaleData[];
+  abnormalities: Abnormality[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -60,6 +60,7 @@ export interface DronePartData {
 
 export interface PartOnSaleData {
   productImage: string;
+  estimateDate: string;
   category: string;
   name: string;
   price: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -40,16 +40,21 @@ export interface GuestInsuranceData {
 }
 
 export interface DronePartData {
-  img: string;
-  name: string;
   id: number;
+  droneImg: string;
+  nickname: string;
   balanceScore: number;
   totalScore: number;
-  dronePart: {
-    kind: string;
-    detail: string;
+  orderDate: string;
+  estimateDate: string;
+  productsInfo: {
+    productImage: string;
+    category: string;
+    name: string;
     price: number;
-    num: number;
+    // salePrice: number;
+    // totalPrice: number;
+    amount: number;
   }[];
 }
 

--- a/src/utils/orderCount.ts
+++ b/src/utils/orderCount.ts
@@ -1,0 +1,12 @@
+export const setOrderCount = (newCount: number) => {
+  localStorage.setItem('orderCount', newCount.toString());
+};
+
+export const getOrderCount = () => {
+  const count = localStorage.getItem('orderCount');
+  if (count) {
+    return count;
+  } else {
+    return 0;
+  }
+};


### PR DESCRIPTION
## 요약(Summary)
- 부품 주문 페이지의 API를 연동했습니다
- resolved https://github.com/Weflo-B/Weflo-FE/issues/15

## 변경 사항(Changes)
- services > orderApi.ts에 주문한 부품의 전체 개수와 각 드론별 부품 개수를 불러오는 함수를 작성했습니다
- utils > orderCount.ts의 setOrderCount와 getOrderCount 함수를 통해 부품 개수를 로컬 스토리지에 저장해서 모든 페이지에서 띄울 수 있게 했습니다

## 리뷰 요구사항
- 머지되면 간단하게라도 리팩토링해보겠습니다.. 너무 필요해보여요 핳
(왠진 모르겠는데 움짤로 만드니까 내비게이션에 갯수 숫자 위치가 좀 깨져보이네요 사진으로 캡쳐하면 괜찮습니다)
<img width="994" alt="image" src="https://github.com/Weflo-B/Weflo-FE/assets/81912226/13ef296b-4c63-4eb5-b035-361f1d09ba55">


## 확인 방법 (선택)
![Mar-10-2024 01-34-18](https://github.com/Weflo-B/Weflo-FE/assets/81912226/67ad42df-71fc-4a50-aadf-4b7dd13e8a42)

