### PR TITLE
[FEAT] 견적서 페이지 API 연동

### DIFF
--- a/src/pages/Estimate/atoms/Completed.module.scss
+++ b/src/pages/Estimate/atoms/Completed.module.scss
@@ -1,11 +1,17 @@
 @import 'src/styles/style.scss';
 
 .container {
+  height: calc(100vh - 93px);
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
   gap: 42px;
+
+  div {
+    color: $main-4;
+    @include H1;
+  }
 
   img {
     margin-bottom: 17px;

--- a/src/pages/Estimate/atoms/Completed.tsx
+++ b/src/pages/Estimate/atoms/Completed.tsx
@@ -1,14 +1,24 @@
+import { useNavigate } from 'react-router-dom';
+
 import IconCompleted from '@/assets/icons/order-completed.svg';
 import Button from '@/components/Button';
 
 import styles from './Completed.module.scss';
 
 export const Completed = () => {
+  const navigate = useNavigate();
+
   return (
     <main className={styles.container}>
       <div>주문 완료</div>
       <img src={IconCompleted} alt="주문 완료" />
-      <Button>주문 배송조회</Button>
+      <Button
+        onClick={() => {
+          navigate('/tracking');
+        }}
+      >
+        주문 배송조회
+      </Button>
     </main>
   );
 };

--- a/src/pages/Estimate/index.tsx
+++ b/src/pages/Estimate/index.tsx
@@ -1,53 +1,37 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
+import { useQuery } from 'react-query';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import Button from '@/components/Button';
 import { Completed } from '@/pages/Estimate/atoms/Completed';
-
-import Test from '../Tracking/atoms/test.png';
+import { USER_ID } from '@/services';
+import { getEstimate } from '@/services/estimateApi';
+import { GetEstimateData } from '@/types';
 
 import styles from './Estimate.module.scss';
 
-const Dummy = [
-  {
-    image: Test,
-    product: '블레이드',
-    description: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-    count: 2,
-    price: 8800,
-  },
-  {
-    image: Test,
-    product: '블레이드',
-    description: 'EVO Lite 플러스 프로펠러 오리지널 액세서리 블레이드 프로펠러',
-    count: 1,
-    price: 40450,
-  },
-  {
-    image: Test,
-    product: '모터',
-    description: '13T 드론 브러시리스 모터 멀티 쿼드 RC A2212 1000KV',
-    count: 1,
-    price: 15830,
-  },
-  {
-    image: Test,
-    product: 'ESC',
-    description: 'DJI Agras 드론 ESC 모듈 T30 T10 T40 T20P',
-    count: 1,
-    price: 15830,
-  },
-];
-
 export const Estimate = () => {
-  const [totalPrice, setTotalPrice] = useState(0);
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const [initialData, setInitialData] = useState<GetEstimateData | null>(null);
+  useQuery({
+    queryKey: ['ESTIMATE', USER_ID],
+    queryFn: () => getEstimate(),
+    staleTime: 300000, // 5분
+    onSuccess: (fetchedData) => {
+      if (!initialData) {
+        setInitialData(fetchedData);
+      }
+    },
+  });
 
-  useEffect(() => {
-    setTotalPrice(Dummy.reduce((acc, item) => acc + item.count * item.price, 0));
-  }, []);
+  const options = {
+    weekday: 'long' as const,
+    year: 'numeric' as const,
+    month: 'long' as const,
+    day: 'numeric' as const,
+  };
 
   if (searchParams.get('completed')) return <Completed />;
 
@@ -60,45 +44,51 @@ export const Estimate = () => {
         </div>
         <span className={styles.title}>견적서</span>
       </div>
-      <section className={styles.estimateContainer}>
-        <div className={styles.estimateTitle}>
-          <span>{`파블로 항공`}</span>
-          <span>주문일 {`2024년 1월 1일`}</span>
-        </div>
-        <div className={styles.estimateInformationContainer}>
-          <table>
-            <thead>
-              <tr>
-                <th>항목</th>
-                <th>세부내용</th>
-                <th>수량</th>
-                <th>단가</th>
-                <th>금액</th>
-              </tr>
-            </thead>
-            <tbody>
-              {Dummy.map((item) => (
-                <tr key={item.description}>
-                  <td>
-                    <div>
-                      <img src={item.image} alt={item.product} />
-                      <span>{item.product}</span>
-                    </div>
-                  </td>
-                  <td>{item.description}</td>
-                  <td>{item.count}</td>
-                  <td>{item.price.toLocaleString()}</td>
-                  <td>{(item.count * item.price).toLocaleString()}</td>
+      {initialData && (
+        <section className={styles.estimateContainer}>
+          <div className={styles.estimateTitle}>
+            <span>{initialData.name}</span>
+            <span>
+              주문일 {new Date(initialData.orderDate).toLocaleDateString('ko-KR', options)}
+            </span>
+          </div>
+          <div className={styles.estimateInformationContainer}>
+            <table>
+              <thead>
+                <tr>
+                  <th>항목</th>
+                  <th>세부내용</th>
+                  <th>수량</th>
+                  <th>단가</th>
+                  <th>금액</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-          <div className={styles.totalPrice}>총액 = {totalPrice.toLocaleString()}원</div>
-          <Button style={{ marginRight: '55px' }} onClick={() => navigate('?completed=true')}>
-            주문하기
-          </Button>
-        </div>
-      </section>
+              </thead>
+              <tbody>
+                {initialData.productsInfo.map((item) => (
+                  <tr key={item.name}>
+                    <td>
+                      <div>
+                        <img src={item.productImage} alt={item.name} />
+                        <span>{item.category}</span>
+                      </div>
+                    </td>
+                    <td>{item.name}</td>
+                    <td>{item.amount}</td>
+                    <td>{item.salePrice.toLocaleString()}</td>
+                    <td>{item.totalPrice.toLocaleString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <div className={styles.totalPrice}>
+              총액 = {initialData.sumPrice.toLocaleString()}원
+            </div>
+            <Button style={{ marginRight: '55px' }} onClick={() => navigate('?completed=true')}>
+              주문하기
+            </Button>
+          </div>
+        </section>
+      )}
     </main>
   );
 };

--- a/src/pages/Order/index.tsx
+++ b/src/pages/Order/index.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useNavigate } from 'react-router-dom';
 
 import FloatingBtn from '@/assets/icons/floatingBtn.svg';
 import { USER_ID } from '@/services';
@@ -14,6 +14,7 @@ import DroneItem from './atoms/DroneItem';
 
 const Order = () => {
   const [allOrders, setAllOrders] = useState<DronePartData[]>();
+  const navigate = useNavigate();
 
   const { data } = useQuery({
     queryKey: ['ORDER_PARTS', 'ALL', USER_ID],
@@ -40,7 +41,13 @@ const Order = () => {
           })}
       </div>
       <div className={styles.floatingBtnContainer}>
-        <button type="button" className={styles.floatingBtn}>
+        <button
+          type="button"
+          className={styles.floatingBtn}
+          onClick={() => {
+            navigate('estimate');
+          }}
+        >
           <img src={FloatingBtn} alt="플로팅 버튼" />
           <div>견적서</div>
         </button>

--- a/src/services/estimateApi.ts
+++ b/src/services/estimateApi.ts
@@ -11,3 +11,14 @@ export const getEstimate = async () => {
   const data = (await response.json()) as { data: GetEstimateData };
   return data.data;
 };
+
+export const patchOrderEstimate = async () => {
+  const response = await fetch(`${BASE_URL}/api/orders/${USER_ID}`);
+
+  if (!response.ok) {
+    throw Error('Failed to update estimate order data');
+  }
+
+  const data = await response.json();
+  return data.isSuccess;
+};

--- a/src/services/estimateApi.ts
+++ b/src/services/estimateApi.ts
@@ -1,0 +1,13 @@
+import { BASE_URL, USER_ID } from '@/services';
+import { GetEstimateData } from '@/types';
+
+export const getEstimate = async () => {
+  const response = await fetch(`${BASE_URL}/api/quotation/${USER_ID}`);
+
+  if (!response.ok) {
+    throw Error('Failed to fetch estimate data');
+  }
+
+  const data = (await response.json()) as { data: GetEstimateData };
+  return data.data;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -85,3 +85,18 @@ export interface DronePartDetailData {
   productsInfo: PartOnSaleData[];
   abnormalities: Abnormality[];
 }
+
+export interface GetEstimateData {
+  name: string;
+  orderDate: string;
+  productsInfo: {
+    productImage: string;
+    category: string;
+    name: string;
+    price: number;
+    salePrice: number;
+    totalPrice: number;
+    amount: number;
+  }[];
+  sumPrice: number;
+}


### PR DESCRIPTION
## 요약(Summary)

- 견적서 페이지 API를 연동했습니다.
- resolved #21 

## 변경 사항(Changes)

- 플로팅 버튼 클릭 시, 이동하는 path를 `/order/estimate`로 설정했습니다.
- react-query를 사용하니까 나름 staleTime도 설정했는데, 그냥 임으로 5분으로 설정했습니다. (시연에서는 큰 의미 없을 거임)

## 리뷰 요구사항

## 확인 방법 (선택)

https://github.com/Weflo-B/Weflo-FE/assets/87255791/cecc59f0-329a-497e-b105-6302258b471f

