### PR TITLE
[FEAT] 주문/배송 페이지 API 연동

### DIFF
--- a/src/components/Dialog/RadioButtonDialog.module.scss
+++ b/src/components/Dialog/RadioButtonDialog.module.scss
@@ -1,0 +1,98 @@
+@import 'src/styles/style.scss';
+
+@keyframes overlayShow {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.overlay {
+  background-color: rgba(0, 0, 0, 0.4);
+  position: fixed;
+  inset: 0;
+  z-index: 20;
+  animation: overlayShow 0.3s;
+}
+
+.content {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  z-index: 30;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 40px;
+
+  width: 630px;
+  height: 360px;
+  padding: 0 98px;
+
+  background-color: $white;
+  border-radius: 24px;
+
+  animation: overlayShow 0.3s;
+
+  .contentInnerContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 32px;
+
+    width: 100%;
+
+    .description {
+      color: $main-5;
+      @include H1;
+    }
+
+    .radioContainer {
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-start;
+      gap: 24px;
+
+      width: 100%;
+
+      label {
+        color: $black;
+        @include H3;
+
+        display: flex;
+        gap: 21px;
+        width: fit-content;
+        cursor: pointer;
+
+        input {
+          appearance: none;
+          -webkit-appearance: none;
+          -moz-appearance: none;
+          width: 30px;
+          height: 30px;
+          background-color: #d9d9d9;
+          box-shadow: 0 0 0 2px #d9d9d9;
+          border-radius: 50%;
+          cursor: pointer;
+        }
+
+        input[type='radio']:checked {
+          background-color: #1f599e;
+          border: 6px solid $white;
+          box-shadow: 0 0 0 2px #1f599e;
+        }
+      }
+    }
+  }
+
+  .closed {
+    position: absolute;
+    top: 32px;
+    right: 32px;
+  }
+}

--- a/src/components/Dialog/RadioButtonDialog.tsx
+++ b/src/components/Dialog/RadioButtonDialog.tsx
@@ -34,8 +34,8 @@ export const RadioButtonDialog = ({
                 <input
                   type="radio"
                   name="group"
-                  value="exchange"
-                  checked={selectedStatus === 'exchange'}
+                  value="교환"
+                  checked={selectedStatus === '교환'}
                   onChange={handleStatusChange}
                 />
                 교환
@@ -44,8 +44,8 @@ export const RadioButtonDialog = ({
                 <input
                   type="radio"
                   name="group"
-                  value="return"
-                  checked={selectedStatus === 'return'}
+                  value="반품"
+                  checked={selectedStatus === '반품'}
                   onChange={handleStatusChange}
                 />
                 반품

--- a/src/components/Dialog/RadioButtonDialog.tsx
+++ b/src/components/Dialog/RadioButtonDialog.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+
+import * as Dialog from '@radix-ui/react-dialog';
+
+import IconClose from '@/assets/icons/dialog/close.svg';
+import Button from '@/components/Button';
+
+import styles from './RadioButtonDialog.module.scss';
+
+interface RadioButtonDialogProps {
+  open: boolean;
+  onCloseClick: () => void;
+  onConfirmClick: () => void;
+  text: string;
+}
+
+export const RadioButtonDialog = ({
+  open,
+  onCloseClick,
+  onConfirmClick,
+  text,
+}: RadioButtonDialogProps) => {
+  const [selectedValue, setSelectedValue] = useState('');
+
+  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    setSelectedValue(event.target.value);
+  };
+
+  return (
+    <Dialog.Root open={open}>
+      <Dialog.Portal>
+        <Dialog.Overlay className={styles.overlay} />
+        <Dialog.Content className={styles.content}>
+          <div className={styles.contentInnerContainer}>
+            <Dialog.Description className={styles.description}>{text}</Dialog.Description>
+            <div className={styles.radioContainer}>
+              <label>
+                <input
+                  type="radio"
+                  name="group"
+                  value="exchange"
+                  checked={selectedValue === 'exchange'}
+                  onChange={handleOptionChange}
+                />
+                교환
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="group"
+                  value="return"
+                  checked={selectedValue === 'return'}
+                  onChange={handleOptionChange}
+                />
+                반품
+              </label>
+            </div>
+          </div>
+          <Dialog.Close asChild>
+            <Button onClick={onConfirmClick}>확인</Button>
+          </Dialog.Close>
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className={styles.closed}
+              aria-label="Close"
+              onClick={onCloseClick}
+            >
+              <img src={IconClose} alt="close" />
+            </button>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+};

--- a/src/components/Dialog/RadioButtonDialog.tsx
+++ b/src/components/Dialog/RadioButtonDialog.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import * as Dialog from '@radix-ui/react-dialog';
 
 import IconClose from '@/assets/icons/dialog/close.svg';
@@ -9,6 +7,8 @@ import styles from './RadioButtonDialog.module.scss';
 
 interface RadioButtonDialogProps {
   open: boolean;
+  selectedStatus: string;
+  handleStatusChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
   onCloseClick: () => void;
   onConfirmClick: () => void;
   text: string;
@@ -16,16 +16,12 @@ interface RadioButtonDialogProps {
 
 export const RadioButtonDialog = ({
   open,
+  selectedStatus,
+  handleStatusChange,
   onCloseClick,
   onConfirmClick,
   text,
 }: RadioButtonDialogProps) => {
-  const [selectedValue, setSelectedValue] = useState('');
-
-  const handleOptionChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setSelectedValue(event.target.value);
-  };
-
   return (
     <Dialog.Root open={open}>
       <Dialog.Portal>
@@ -39,8 +35,8 @@ export const RadioButtonDialog = ({
                   type="radio"
                   name="group"
                   value="exchange"
-                  checked={selectedValue === 'exchange'}
-                  onChange={handleOptionChange}
+                  checked={selectedStatus === 'exchange'}
+                  onChange={handleStatusChange}
                 />
                 교환
               </label>
@@ -49,8 +45,8 @@ export const RadioButtonDialog = ({
                   type="radio"
                   name="group"
                   value="return"
-                  checked={selectedValue === 'return'}
-                  onChange={handleOptionChange}
+                  checked={selectedStatus === 'return'}
+                  onChange={handleStatusChange}
                 />
                 반품
               </label>

--- a/src/pages/Tracking/atoms/MonthDropdown/index.tsx
+++ b/src/pages/Tracking/atoms/MonthDropdown/index.tsx
@@ -5,15 +5,17 @@
 import { useEffect, useRef, useState } from 'react';
 
 import IconDropdown from '@/assets/icons/dropdown.svg';
+import { GetTrackingData } from '@/types';
 
 import styles from './MonthDropdown.module.scss';
 
 interface MonthDropdownProps {
   month: number;
   setMonth: (month: number) => void;
+  setInitialData: (data: GetTrackingData | null) => void;
 }
 
-export const MonthDropdown = ({ month, setMonth }: MonthDropdownProps) => {
+export const MonthDropdown = ({ month, setMonth, setInitialData }: MonthDropdownProps) => {
   const [activeDropdown, setActiveDropdown] = useState<boolean>(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -53,6 +55,7 @@ export const MonthDropdown = ({ month, setMonth }: MonthDropdownProps) => {
                 className={`${month === index + 1 && styles.activeMonth}`}
                 onClick={() => {
                   setMonth(index + 1);
+                  setInitialData(null);
                   setActiveDropdown(false);
                 }}
               >

--- a/src/pages/Tracking/atoms/OrderInformation/index.tsx
+++ b/src/pages/Tracking/atoms/OrderInformation/index.tsx
@@ -2,20 +2,28 @@ import styles from './OrderInformation.module.scss';
 
 interface OrderInformationProps {
   month: number;
-  information: { month: number; paymentMonth: number; paymentDate: number; totalPrice: number };
+  sumPrice: number;
 }
 
-export const OrderInformation = ({ month, information }: OrderInformationProps) => {
+export const OrderInformation = ({ month, sumPrice }: OrderInformationProps) => {
+  const today = new Date();
+
   return (
     <section className={styles.historyContainer}>
       <div className={styles.title}>
         <div className={styles.orderTitle}>{month}월의 주문 내역</div>
         <div className={styles.orderDescription}>
-          <span className={styles.dueDate}>결제 예정일 | </span>
-          <span>{`${information.paymentMonth}월 ${information.paymentDate}일`}</span>
+          {month > today.getMonth() + 1 && <span className={styles.dueDate}>결제 예정일 | </span>}
+          {month === today.getMonth() + 1 && (
+            <span className={styles.dueDate}>
+              {today.getDate() < 15 ? '결제 완료일 | ' : '결제 예정일 | '}
+            </span>
+          )}
+          {month < today.getMonth() + 1 && <span className={styles.dueDate}>결제 완료일 | </span>}
+          <span>{`${month + 1 > 12 ? 1 : month + 1}월 ${15}일`}</span>
         </div>
       </div>
-      <div className={styles.totalPrice}>{`${information.totalPrice.toLocaleString()}원`}</div>
+      <div className={styles.totalPrice}>{`${sumPrice.toLocaleString()}원`}</div>
     </section>
   );
 };

--- a/src/pages/Tracking/atoms/OrderInformation/index.tsx
+++ b/src/pages/Tracking/atoms/OrderInformation/index.tsx
@@ -11,7 +11,17 @@ export const OrderInformation = ({ month, sumPrice }: OrderInformationProps) => 
   return (
     <section className={styles.historyContainer}>
       <div className={styles.title}>
-        <div className={styles.orderTitle}>{month}월의 주문 내역</div>
+        {month > today.getMonth() + 1 && (
+          <div className={styles.orderTitle}>{month}월의 결제 내역</div>
+        )}
+        {month === today.getMonth() + 1 && (
+          <div className={styles.orderTitle}>
+            {month}월의 {today.getDate() < 15 ? '결제' : '주문'} 내역
+          </div>
+        )}
+        {month < today.getMonth() + 1 && (
+          <div className={styles.orderTitle}>{month}월의 주문 내역</div>
+        )}
         <div className={styles.orderDescription}>
           {month > today.getMonth() + 1 && <span className={styles.dueDate}>결제 예정일 | </span>}
           {month === today.getMonth() + 1 && (

--- a/src/pages/Tracking/atoms/OrderList/index.tsx
+++ b/src/pages/Tracking/atoms/OrderList/index.tsx
@@ -1,61 +1,54 @@
 import { Link } from 'react-router-dom';
 
 import Button from '@/components/Button';
-import { OrderListData } from '@/types';
+import { groupByOrderDate } from '@/pages/Tracking/atoms/OrderSteps/groupByOrderDate';
+import { OrderHistory } from '@/types';
 
 import styles from './OrderList.module.scss';
 
 interface OrderListProps {
-  orderList: OrderListData[];
+  orderList: OrderHistory[];
 }
 
-const ORDER_STEP_KOR: { [key: string]: string } = {
-  preparing: '배송 준비중',
-  delivering: '배송중',
-  completed: '배송 완료',
-  confirm: '구매 확정',
-  cancel: '주문 취소',
-};
-
 export const OrderList = ({ orderList }: OrderListProps) => {
+  const groupOrderList = groupByOrderDate(orderList);
+  console.log(Object.keys(groupOrderList));
+
   return (
     <section className={styles.listContainer}>
       <div className={styles.orderListContainer}>
-        {orderList.map((list) => {
-          if (list.items.length > 0)
-            return (
-              <div key={list.date}>
-                <div className={styles.date}>{list.date}</div>
-                <div className={styles.itemList}>
-                  {list.items.map((item) => (
-                    <div
-                      key={item.title}
-                      className={`${styles.itemContainer} ${item.state === 'cancel' && styles.cancel}`}
-                    >
-                      <div className={styles.itemInformationContainer}>
-                        <img src={item.image} alt="상품 이미지" />
-                        <div className={styles.itemInformation}>
-                          <span className={styles.title}>{item.title}</span>
-                          <span className={styles.description}>
-                            {item.subTitle} | 수량 {item.count} 개
-                          </span>
-                          <span className={styles.state}>{ORDER_STEP_KOR[item.state]}</span>
-                          <span className={styles.price}>{item.price.toLocaleString()}원</span>
-                        </div>
-                      </div>
-                      {item.state !== 'cancel' && (
-                        <Link to="detail">
-                          <Button style={{ height: 'fit-content', padding: '20px 46px' }}>
-                            배송상세 조회
-                          </Button>
-                        </Link>
-                      )}
+        {Object.keys(groupOrderList).map((date) => (
+          <div key={date}>
+            <div className={styles.date}>{date}</div>
+            <div className={styles.itemList}>
+              {groupOrderList[date].map((item) => (
+                <div
+                  key={item.id}
+                  className={`${styles.itemContainer} ${item.status === '주문취소' && styles.cancel}`}
+                >
+                  <div className={styles.itemInformationContainer}>
+                    <img src={item.productImage} alt="상품 이미지" />
+                    <div className={styles.itemInformation}>
+                      <span className={styles.title}>{item.category}</span>
+                      <span className={styles.description}>
+                        {item.name} | 수량 {item.amount} 개
+                      </span>
+                      <span className={styles.state}>{item.status}</span>
+                      <span className={styles.price}>{item.salePrice.toLocaleString()}원</span>
                     </div>
-                  ))}
+                  </div>
+                  {item.status !== '주문취소' && (
+                    <Link to="detail">
+                      <Button style={{ height: 'fit-content', padding: '20px 46px' }}>
+                        배송상세 조회
+                      </Button>
+                    </Link>
+                  )}
                 </div>
-              </div>
-            );
-        })}
+              ))}
+            </div>
+          </div>
+        ))}
       </div>
     </section>
   );

--- a/src/pages/Tracking/atoms/OrderList/index.tsx
+++ b/src/pages/Tracking/atoms/OrderList/index.tsx
@@ -37,7 +37,7 @@ export const OrderList = ({ orderList }: OrderListProps) => {
                     </div>
                   </div>
                   {item.status !== '주문취소' && (
-                    <Link to="detail">
+                    <Link to={`detail/${item.id}`}>
                       <Button style={{ height: 'fit-content', padding: '20px 46px' }}>
                         배송상세 조회
                       </Button>

--- a/src/pages/Tracking/atoms/OrderList/index.tsx
+++ b/src/pages/Tracking/atoms/OrderList/index.tsx
@@ -12,7 +12,6 @@ interface OrderListProps {
 
 export const OrderList = ({ orderList }: OrderListProps) => {
   const groupOrderList = groupByOrderDate(orderList);
-  console.log(Object.keys(groupOrderList));
 
   return (
     <section className={styles.listContainer}>

--- a/src/pages/Tracking/atoms/OrderList/index.tsx
+++ b/src/pages/Tracking/atoms/OrderList/index.tsx
@@ -18,7 +18,7 @@ export const OrderList = ({ orderList }: OrderListProps) => {
       <div className={styles.orderListContainer}>
         {Object.keys(groupOrderList).map((date) => (
           <div key={date}>
-            <div className={styles.date}>{date}</div>
+            <div className={styles.date}>{date.replaceAll('-', '.')}</div>
             <div className={styles.itemList}>
               {groupOrderList[date].map((item) => (
                 <div

--- a/src/pages/Tracking/atoms/OrderSteps/groupByOrderDate.ts
+++ b/src/pages/Tracking/atoms/OrderSteps/groupByOrderDate.ts
@@ -1,0 +1,24 @@
+import { OrderHistory } from '@/types';
+
+export const groupByOrderDate = (orderList: OrderHistory[]): { [key: string]: OrderHistory[] } => {
+  const sortedGroupOrderList: { [key: string]: OrderHistory[] } = {};
+  const groupOrderList = orderList.reduce((result: { [key: string]: OrderHistory[] }, order) => {
+    const orderDateKey = order.orderDate;
+
+    if (!result[orderDateKey]) {
+      result[orderDateKey] = [];
+    }
+
+    result[orderDateKey].push(order);
+
+    return result;
+  }, {});
+
+  Object.keys(groupOrderList)
+    .sort()
+    .forEach((key) => {
+      sortedGroupOrderList[key] = groupOrderList[key];
+    });
+
+  return sortedGroupOrderList;
+};

--- a/src/pages/Tracking/atoms/OrderSteps/index.tsx
+++ b/src/pages/Tracking/atoms/OrderSteps/index.tsx
@@ -3,8 +3,8 @@ import RightChevornProcess from '@/assets/icons/rightChevron-process.svg';
 import styles from './OrderSteps.module.scss';
 
 interface OrderStepsProps {
-  acitveState: string;
-  setActiveState: (state: string) => void;
+  activeStatus: string;
+  setActiveStatus: (state: string) => void;
   preparing: number;
   delivering: number;
   completed: number;
@@ -12,8 +12,8 @@ interface OrderStepsProps {
 }
 
 export const OrderSteps = ({
-  acitveState,
-  setActiveState,
+  activeStatus,
+  setActiveStatus,
   preparing,
   delivering,
   completed,
@@ -22,15 +22,15 @@ export const OrderSteps = ({
   return (
     <section className={styles.stepsContainer}>
       <div className={styles.stepsContent}>
-        <button type="button" className={styles.totalCount} onClick={() => setActiveState('total')}>
+        <button type="button" className={styles.totalCount} onClick={() => setActiveStatus('')}>
           <span>전체</span>
           <span>{`${preparing + delivering + completed + confirm}건`}</span>
         </button>
         <div className={styles.stepList}>
           <button
             type="button"
-            className={`${styles.step} ${acitveState === 'preparing' && styles.active}`}
-            onClick={() => setActiveState('preparing')}
+            className={`${styles.step} ${activeStatus === '배송준비중' && styles.active}`}
+            onClick={() => setActiveStatus('배송준비중')}
           >
             <span>배송준비중</span>
             <span>{`${preparing}건`}</span>
@@ -38,8 +38,8 @@ export const OrderSteps = ({
           <img src={RightChevornProcess} alt="right-chevron-process" />
           <button
             type="button"
-            className={`${styles.step} ${acitveState === 'delivering' && styles.active}`}
-            onClick={() => setActiveState('delivering')}
+            className={`${styles.step} ${activeStatus === '배송중' && styles.active}`}
+            onClick={() => setActiveStatus('배송중')}
           >
             <span>배송중</span>
             <span>{`${delivering}건`}</span>
@@ -47,8 +47,8 @@ export const OrderSteps = ({
           <img src={RightChevornProcess} alt="right-chevron-process" />
           <button
             type="button"
-            className={`${styles.step} ${acitveState === 'completed' && styles.active}`}
-            onClick={() => setActiveState('completed')}
+            className={`${styles.step} ${activeStatus === '배송완료' && styles.active}`}
+            onClick={() => setActiveStatus('배송완료')}
           >
             <span>배송완료</span>
             <span>{`${completed}건`}</span>
@@ -56,8 +56,8 @@ export const OrderSteps = ({
           <img src={RightChevornProcess} alt="right-chevron-process" />
           <button
             type="button"
-            className={`${styles.step} ${acitveState === 'confirm' && styles.active}`}
-            onClick={() => setActiveState('confirm')}
+            className={`${styles.step} ${activeStatus === '구매확정' && styles.active}`}
+            onClick={() => setActiveStatus('구매확정')}
           >
             <span>구매확정</span>
             <span>{`${confirm}건`}</span>

--- a/src/pages/Tracking/index.tsx
+++ b/src/pages/Tracking/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { useQuery } from 'react-query';
 
@@ -19,13 +19,16 @@ export const Tracking = () => {
   const { data } = useQuery({
     queryKey: ['TRACKING', USER_ID, month, activeStatus],
     queryFn: () => getTracking(month, activeStatus),
-    staleTime: 300000, // 5분
     onSuccess: (fetchedData) => {
       if (!initialData) {
         setInitialData(fetchedData);
       }
     },
   });
+
+  useEffect(() => {
+    setInitialData(null);
+  }, [month]);
 
   return (
     <main className={styles.container}>

--- a/src/pages/Tracking/index.tsx
+++ b/src/pages/Tracking/index.tsx
@@ -33,7 +33,7 @@ export const Tracking = () => {
         <span className={styles.pageDescription}>주문/배송조회</span>
         <div className={styles.titleInnerContainer}>
           <span className={styles.title}>주문 / 배송조회</span>
-          <MonthDropdown month={month} setMonth={setMonth} />
+          <MonthDropdown month={month} setMonth={setMonth} setInitialData={setInitialData} />
         </div>
       </div>
       <div className={styles.content}>
@@ -64,7 +64,11 @@ export const Tracking = () => {
             }
           />
         )}
-        {data && <OrderList orderList={data.orderHistories} />}
+        {data && (
+          <OrderList
+            orderList={data.orderHistories.filter((history) => history.status !== '주문대기중')}
+          />
+        )}
       </div>
     </main>
   );

--- a/src/pages/Tracking/index.tsx
+++ b/src/pages/Tracking/index.tsx
@@ -8,84 +8,9 @@ import { OrderList } from '@/pages/Tracking/atoms/OrderList';
 import { OrderSteps } from '@/pages/Tracking/atoms/OrderSteps';
 import { USER_ID } from '@/services';
 import { getTracking } from '@/services/trackingApi';
-import { GetTrackingData, OrderListData } from '@/types';
+import { GetTrackingData } from '@/types';
 
 import styles from './Tracking.module.scss';
-import DummyImage from './atoms/test.png';
-
-const Dummy: OrderListData[] = [
-  {
-    date: '2024.02.01',
-    items: [
-      {
-        image: DummyImage,
-        title: '블레이드',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 1,
-        state: 'cancel',
-        price: 7500,
-      },
-      {
-        image: DummyImage,
-        title: '블레이드2',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 2,
-        state: 'preparing',
-        price: 7500,
-      },
-      {
-        image: DummyImage,
-        title: '블레이드3',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 2,
-        state: 'delivering',
-        price: 7500,
-      },
-      {
-        image: DummyImage,
-        title: '블레이드4',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 2,
-        state: 'completed',
-        price: 7500,
-      },
-    ],
-  },
-  {
-    date: '2024.02.02',
-    items: [
-      {
-        image: DummyImage,
-        title: '블레이드5',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 2,
-        state: 'completed',
-        price: 7500,
-      },
-      {
-        image: DummyImage,
-        title: '블레이드6',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 10,
-        state: 'confirm',
-        price: 7500,
-      },
-    ],
-  },
-  {
-    date: '2024.02.03',
-    items: [
-      {
-        image: DummyImage,
-        title: '블레이드7',
-        subTitle: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-        count: 2,
-        state: 'confirm',
-        price: 7500,
-      },
-    ],
-  },
-];
 
 const Dummy2 = {
   month: 3,
@@ -97,7 +22,7 @@ const Dummy2 = {
 export const Tracking = () => {
   const [activeStatus, setActiveStatus] = useState<string>('');
   const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
-  const [initialData, setInitialData] = useState<GetTrackingData>(null);
+  const [initialData, setInitialData] = useState<GetTrackingData | null>(null);
   const { data } = useQuery({
     queryKey: ['TRACKING', USER_ID, month, activeStatus],
     queryFn: () => getTracking(month, activeStatus),
@@ -146,16 +71,7 @@ export const Tracking = () => {
             }
           />
         )}
-        <OrderList
-          orderList={
-            activeStatus === ''
-              ? Dummy
-              : Dummy.map((order) => ({
-                  date: order.date,
-                  items: order.items.filter((item) => item.state === activeStatus),
-                }))
-          }
-        />
+        {data && <OrderList orderList={data.orderHistories} />}
       </div>
     </main>
   );

--- a/src/pages/Tracking/index.tsx
+++ b/src/pages/Tracking/index.tsx
@@ -12,13 +12,6 @@ import { GetTrackingData } from '@/types';
 
 import styles from './Tracking.module.scss';
 
-const Dummy2 = {
-  month: 3,
-  paymentMonth: 4,
-  paymentDate: 15,
-  totalPrice: 77980,
-};
-
 export const Tracking = () => {
   const [activeStatus, setActiveStatus] = useState<string>('');
   const [month, setMonth] = useState<number>(new Date().getMonth() + 1);
@@ -44,7 +37,7 @@ export const Tracking = () => {
         </div>
       </div>
       <div className={styles.content}>
-        <OrderInformation month={month} information={Dummy2} />
+        {initialData && <OrderInformation month={month} sumPrice={initialData.sumPrice} />}
         {initialData && (
           <OrderSteps
             activeStatus={activeStatus}

--- a/src/pages/TrackingDetail/TrackingDetail.module.scss
+++ b/src/pages/TrackingDetail/TrackingDetail.module.scss
@@ -36,5 +36,10 @@
     display: flex;
     flex-direction: column;
     gap: 38px;
+
+    .deliveryContainer {
+      display: flex;
+      gap: 54px;
+    }
   }
 }

--- a/src/pages/TrackingDetail/atoms/Information/BuyerInformation.tsx
+++ b/src/pages/TrackingDetail/atoms/Information/BuyerInformation.tsx
@@ -1,0 +1,32 @@
+import { BuyerInfos } from '@/types';
+
+import styles from './Information.module.scss';
+
+interface BuyerInformationProps {
+  buyerInfos: BuyerInfos;
+}
+
+export const BuyerInformation = ({ buyerInfos }: BuyerInformationProps) => {
+  return (
+    <section className={styles.container}>
+      <div className={styles.title}>배송지 정보</div>
+      <div className={styles.content}>
+        <div>
+          <span>수신자</span>
+          <span>|</span>
+          <span>{buyerInfos.name}</span>
+        </div>
+        <div>
+          <span>연락처</span>
+          <span>|</span>
+          <span>{buyerInfos.tel}</span>
+        </div>
+        <div>
+          <span>배송지</span>
+          <span>|</span>
+          <span>{buyerInfos.address}</span>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/pages/TrackingDetail/atoms/Information/Information.module.scss
+++ b/src/pages/TrackingDetail/atoms/Information/Information.module.scss
@@ -1,0 +1,42 @@
+@import 'src/styles/style.scss';
+
+.container {
+  flex-grow: 1;
+  background-color: $white;
+  box-shadow: 6px 6px 54px rgba(0, 0, 0, 0.05);
+  border-radius: 24px;
+  padding: 34px 40px;
+
+  display: flex;
+  flex-direction: column;
+  gap: 33px;
+
+  .title {
+    color: $main-2;
+    @include H3;
+  }
+
+  .content {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+
+    div {
+      display: flex;
+      gap: 17px;
+
+      span {
+        color: $black;
+        @include H4;
+      }
+
+      :first-child {
+        width: 100px;
+      }
+
+      :nth-child(3) {
+        margin-left: 30px;
+      }
+    }
+  }
+}

--- a/src/pages/TrackingDetail/atoms/Information/SellerInformation.tsx
+++ b/src/pages/TrackingDetail/atoms/Information/SellerInformation.tsx
@@ -1,0 +1,36 @@
+import { SellerInfos } from '@/types';
+
+import styles from './Information.module.scss';
+
+interface SellerInformationProps {
+  sellerInfos: SellerInfos;
+}
+export const SellerInformation = ({ sellerInfos }: SellerInformationProps) => {
+  return (
+    <section className={styles.container}>
+      <div className={styles.title}>택배사 상세</div>
+      <div className={styles.content}>
+        <div>
+          <span>택배사</span>
+          <span>|</span>
+          <span>{sellerInfos.deliveryCompany}</span>
+        </div>
+        <div>
+          <span>전화번호</span>
+          <span>|</span>
+          <span>{sellerInfos.deliveryTel}</span>
+        </div>
+        <div>
+          <span>송장번호</span>
+          <span>|</span>
+          <span>{sellerInfos.invoiceNumber}</span>
+        </div>
+        <div>
+          <span>판매자</span>
+          <span>|</span>
+          <span>{sellerInfos.seller}</span>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/pages/TrackingDetail/atoms/ProductInformation/ProductInformation.module.scss
+++ b/src/pages/TrackingDetail/atoms/ProductInformation/ProductInformation.module.scss
@@ -2,7 +2,7 @@
 
 .container {
   display: flex;
-  justify-content: space-between;
+  gap: 85px;
   position: relative;
 
   .arrivalInformation {

--- a/src/pages/TrackingDetail/atoms/ProductInformation/index.tsx
+++ b/src/pages/TrackingDetail/atoms/ProductInformation/index.tsx
@@ -1,33 +1,48 @@
+import { ProductInfos } from '@/types';
+
 import styles from './ProductInformation.module.scss';
 
 interface ProductInformationProps {
-  product: {
-    arrivalDate: string;
-    startDate: string;
-    image: string;
-    name: string;
-    description: string;
-    count: number;
-    price: number;
-    step: string;
-  };
+  estimateDate: string;
+  currentStatus: string;
+  productsInfos: ProductInfos;
 }
 
-export const ProductInformation = ({ product }: ProductInformationProps) => {
+export const ProductInformation = ({
+  estimateDate,
+  currentStatus,
+  productsInfos,
+}: ProductInformationProps) => {
+  const options = {
+    weekday: 'long' as const,
+    year: 'numeric' as const,
+    month: 'long' as const,
+    day: 'numeric' as const,
+  };
+
   return (
     <section className={styles.container}>
       <div className={styles.arrivalInformation}>
-        <span>{product.arrivalDate} 도착 예정</span>
-        <span>고객님이 주문하신 상품이 배송중입니다.</span>
+        {currentStatus === '배송완료' ? (
+          <>
+            <span>{estimateDate} 배송 완료</span>
+            <span>고객님이 주문하신 상품이 배송완료되었어요.</span>
+          </>
+        ) : (
+          <>
+            <span>{new Date(estimateDate).toLocaleDateString('ko-KR', options)} 도착 예정</span>
+            <span>고객님이 주문하신 상품이 배송중입니다.</span>
+          </>
+        )}
       </div>
       <div className={styles.product}>
-        <img src={product.image} alt={product.name} />
+        <img src={productsInfos.productImage} alt={productsInfos.name} />
         <div className={styles.productInformation}>
-          <span>{product.name}</span>
+          <span>{productsInfos.category}</span>
           <span>
-            {product.description} | 수량 {product.count} 개
+            {productsInfos.name} | 수량 {productsInfos.amount} 개
           </span>
-          <span>{product.price.toLocaleString()}원</span>
+          <span>{productsInfos.salePrice.toLocaleString()}원</span>
         </div>
       </div>
     </section>

--- a/src/pages/TrackingDetail/atoms/TrackingStep/index.tsx
+++ b/src/pages/TrackingDetail/atoms/TrackingStep/index.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import IconArrived from '@/assets/icons/order/arrived.svg';
 import IconDelivery from '@/assets/icons/order/delivery.svg';
 import IconReceived from '@/assets/icons/order/received.svg';
@@ -32,7 +34,7 @@ export const TrackingStep = ({ currentStatus, pastDates }: TrackingStepProps) =>
       <div className={styles.innerContainer}>
         <div className={styles.stepList}>
           {DELIVERING_STEP.map((item, index) => (
-            <>
+            <React.Fragment key={item.step}>
               <div className={`${styles.stepBox} ${currentStatus === item.step && styles.active}`}>
                 <div className={styles.description}>
                   <span className={styles.step}>{item.step}</span>
@@ -47,7 +49,7 @@ export const TrackingStep = ({ currentStatus, pastDates }: TrackingStepProps) =>
               {index !== DELIVERING_STEP.length - 1 && (
                 <img src={RightChevornProcess} alt="rightChevron" />
               )}
-            </>
+            </React.Fragment>
           ))}
         </div>
         <span>

--- a/src/pages/TrackingDetail/atoms/TrackingStep/index.tsx
+++ b/src/pages/TrackingDetail/atoms/TrackingStep/index.tsx
@@ -3,43 +3,43 @@ import IconDelivery from '@/assets/icons/order/delivery.svg';
 import IconReceived from '@/assets/icons/order/received.svg';
 import IconRoute from '@/assets/icons/order/route.svg';
 import RightChevornProcess from '@/assets/icons/rightChevron-process.svg';
+import { PastDates } from '@/types';
 
 import styles from './TrackingStep.module.scss';
 
 const DELIVERING_STEP = [
-  { id: 'start', step: '배송시작', image: IconDelivery },
-  { id: '2', step: '잡화처리', image: IconReceived },
-  { id: '3', step: '간선상차', image: IconDelivery },
-  { id: '4', step: '간선하차', image: IconRoute },
-  { id: 'arrived', step: '배송완료', image: IconArrived },
+  { step: '배송시작', image: IconDelivery },
+  { step: '잡화처리', image: IconReceived },
+  { step: '간선상차', image: IconDelivery },
+  { step: '간선하차', image: IconRoute },
+  { step: '배송완료', image: IconArrived },
 ];
 
 interface TrackingStepProps {
-  product: {
-    arrivalDate: string;
-    startDate: string;
-    image: string;
-    name: string;
-    description: string;
-    count: number;
-    price: number;
-    step: string;
-  };
+  currentStatus: string;
+  pastDates: PastDates[];
 }
 
-export const TrackingStep = ({ product }: TrackingStepProps) => {
+export const TrackingStep = ({ currentStatus, pastDates }: TrackingStepProps) => {
+  const options = {
+    weekday: 'long' as const,
+    month: 'long' as const,
+    day: 'numeric' as const,
+  };
+
   return (
     <section className={styles.container}>
       <div className={styles.innerContainer}>
         <div className={styles.stepList}>
           {DELIVERING_STEP.map((item, index) => (
             <>
-              <div className={`${styles.stepBox} ${product.step === item.id && styles.active}`}>
+              <div className={`${styles.stepBox} ${currentStatus === item.step && styles.active}`}>
                 <div className={styles.description}>
                   <span className={styles.step}>{item.step}</span>
-                  {item.id === 'start' && <span className={styles.date}>{product.startDate}</span>}
-                  {item.id === 'arrived' && (
-                    <span className={styles.date}>{product.arrivalDate}</span>
+                  {pastDates[index] && (
+                    <span className={styles.date}>
+                      {new Date(pastDates[index].date).toLocaleDateString('ko-KR', options)}
+                    </span>
                   )}
                 </div>
                 <img src={item.image} alt={item.step} />

--- a/src/pages/TrackingDetail/index.tsx
+++ b/src/pages/TrackingDetail/index.tsx
@@ -11,20 +11,7 @@ import { ProductInformation } from '@/pages/TrackingDetail/atoms/ProductInformat
 import { TrackingStep } from '@/pages/TrackingDetail/atoms/TrackingStep';
 import { getTrackingDetail } from '@/services/trackingApi';
 
-import TestImg from '../Tracking/atoms/test.png';
-
 import styles from './TrackingDetail.module.scss';
-
-const Dummy = {
-  arrivalDate: '2월 28일 수요일',
-  startDate: '2월 24일 월요일',
-  image: TestImg,
-  name: '블레이드',
-  description: 'DJI 아바타 드론 블레이드 프로펠러 교체용 경량 날개 팬 프로펠러 액세서리',
-  count: 1,
-  price: 7500,
-  step: 'arrived',
-};
 
 export const TrackingDetail = () => {
   const [activeCancelModal, setActiveCancelModal] = useState(false);
@@ -53,7 +40,7 @@ export const TrackingDetail = () => {
               currentStatus={data.currentStatus}
               productsInfos={data.productInfos}
             />
-            <TrackingStep product={Dummy} />
+            <TrackingStep currentStatus={data.currentStatus} pastDates={data.pastDates} />
           </div>
           {data.currentStatus === '주문대기중' && (
             <Button

--- a/src/pages/TrackingDetail/index.tsx
+++ b/src/pages/TrackingDetail/index.tsx
@@ -83,7 +83,7 @@ export const TrackingDetail = () => {
               주문 취소하기
             </Button>
           )}
-          {productData.currentStatus !== '배송완료' && (
+          {(productData.currentStatus === '배송완료' || productData.currentStatus === '종료') && (
             <Button
               style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
               onClick={() => setActiveExchangeReturnModal(true)} /* API 연결할 땐 이 로직 아님 */

--- a/src/pages/TrackingDetail/index.tsx
+++ b/src/pages/TrackingDetail/index.tsx
@@ -7,6 +7,8 @@ import IconCancel from '@/assets/icons/dialog/cancel.svg';
 import IconCompleted from '@/assets/icons/dialog/completed.svg';
 import Button from '@/components/Button';
 import { DefaultDialog } from '@/components/Dialog/DefaultDialog';
+import { BuyerInformation } from '@/pages/TrackingDetail/atoms/Information/BuyerInformation';
+import { SellerInformation } from '@/pages/TrackingDetail/atoms/Information/SellerInformation';
 import { ProductInformation } from '@/pages/TrackingDetail/atoms/ProductInformation';
 import { TrackingStep } from '@/pages/TrackingDetail/atoms/TrackingStep';
 import { getTrackingDetail } from '@/services/trackingApi';
@@ -40,6 +42,10 @@ export const TrackingDetail = () => {
               currentStatus={data.currentStatus}
               productsInfos={data.productInfos}
             />
+            <div className={styles.deliveryContainer}>
+              <SellerInformation sellerInfos={data.sellerInfos} />
+              <BuyerInformation buyerInfos={data.buyerInfos} />
+            </div>
             <TrackingStep currentStatus={data.currentStatus} pastDates={data.pastDates} />
           </div>
           {data.currentStatus === '주문대기중' && (

--- a/src/pages/TrackingDetail/index.tsx
+++ b/src/pages/TrackingDetail/index.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import IconCancel from '@/assets/icons/dialog/cancel.svg';
 import IconCompleted from '@/assets/icons/dialog/completed.svg';
@@ -8,6 +9,7 @@ import Button from '@/components/Button';
 import { DefaultDialog } from '@/components/Dialog/DefaultDialog';
 import { ProductInformation } from '@/pages/TrackingDetail/atoms/ProductInformation';
 import { TrackingStep } from '@/pages/TrackingDetail/atoms/TrackingStep';
+import { getTrackingDetail } from '@/services/trackingApi';
 
 import TestImg from '../Tracking/atoms/test.png';
 
@@ -28,59 +30,70 @@ export const TrackingDetail = () => {
   const [activeCancelModal, setActiveCancelModal] = useState(false);
   const [activeCompletedModal, setActiveCompletedModal] = useState(false);
   const navigate = useNavigate();
+  const { historyId } = useParams();
+  const { data } = useQuery({
+    queryKey: ['TRACKING_DETAIL', historyId],
+    queryFn: () => getTrackingDetail(parseInt(historyId ? historyId : '0')),
+    staleTime: 300000, // 5분
+  });
 
-  return (
-    <>
-      <main className={styles.container}>
-        <div className={styles.titleContainer}>
-          <span className={styles.pageDescription}>주문/배송조회</span>
-          <div className={styles.titleInnerContainer}>
-            <span className={styles.title}>주문 / 배송조회</span>
+  if (data)
+    return (
+      <>
+        <main className={styles.container}>
+          <div className={styles.titleContainer}>
+            <span className={styles.pageDescription}>주문/배송조회</span>
+            <div className={styles.titleInnerContainer}>
+              <span className={styles.title}>주문 / 배송조회</span>
+            </div>
           </div>
-        </div>
-        <div className={styles.content}>
-          <ProductInformation product={Dummy} />
-          <TrackingStep product={Dummy} />
-        </div>
-        {Dummy.step === 'prepare' && (
-          <Button
-            style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
-            onClick={() => setActiveCancelModal(true)} /* API 연결할 땐 이 로직 아님 */
-          >
-            주문 취소하기
-          </Button>
+          <div className={styles.content}>
+            <ProductInformation
+              estimateDate={data.estimateDate}
+              currentStatus={data.currentStatus}
+              productsInfos={data.productInfos}
+            />
+            <TrackingStep product={Dummy} />
+          </div>
+          {data.currentStatus === '주문대기중' && (
+            <Button
+              style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
+              onClick={() => setActiveCancelModal(true)} /* API 연결할 땐 이 로직 아님 */
+            >
+              주문 취소하기
+            </Button>
+          )}
+          {data.currentStatus === '배송완료' && (
+            <Button
+              style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
+              onClick={() => setActiveCompletedModal(true)} /* API 연결할 땐 이 로직 아님 */
+            >
+              교환/반품하기
+            </Button>
+          )}
+        </main>
+        {activeCancelModal && (
+          <DefaultDialog
+            icon={<img src={IconCancel} alt="icon" />}
+            text="주문이 취소되었습니다!"
+            open={activeCancelModal}
+            onClick={() => {
+              setActiveCancelModal(false);
+              navigate('/tracking');
+            }}
+          />
         )}
-        {Dummy.step === 'arrived' && (
-          <Button
-            style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
-            onClick={() => setActiveCompletedModal(true)} /* API 연결할 땐 이 로직 아님 */
-          >
-            교환/반품하기
-          </Button>
+        {activeCompletedModal && (
+          <DefaultDialog
+            icon={<img src={IconCompleted} alt="icon" />}
+            text="교환 / 반품 접수가 완료되었어요!"
+            open={activeCompletedModal}
+            onClick={() => {
+              setActiveCompletedModal(false);
+              navigate('/tracking');
+            }}
+          />
         )}
-      </main>
-      {activeCancelModal && (
-        <DefaultDialog
-          icon={<img src={IconCancel} alt="icon" />}
-          text="주문이 취소되었습니다!"
-          open={activeCancelModal}
-          onClick={() => {
-            setActiveCancelModal(false);
-            navigate('/tracking');
-          }}
-        />
-      )}
-      {activeCompletedModal && (
-        <DefaultDialog
-          icon={<img src={IconCompleted} alt="icon" />}
-          text="교환 / 반품 접수가 완료되었어요!"
-          open={activeCompletedModal}
-          onClick={() => {
-            setActiveCompletedModal(false);
-            navigate('/tracking');
-          }}
-        />
-      )}
-    </>
-  );
+      </>
+    );
 };

--- a/src/pages/TrackingDetail/index.tsx
+++ b/src/pages/TrackingDetail/index.tsx
@@ -86,7 +86,7 @@ export const TrackingDetail = () => {
           {(productData.currentStatus === '배송완료' || productData.currentStatus === '종료') && (
             <Button
               style={{ position: 'absolute', bottom: '80px', left: '1565px' }}
-              onClick={() => setActiveExchangeReturnModal(true)} /* API 연결할 땐 이 로직 아님 */
+              onClick={() => setActiveExchangeReturnModal(true)}
             >
               교환/반품하기
             </Button>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -24,8 +24,10 @@ export const Router = () => {
           <Route path="detail/:droneId" element={<OrderDetail />} />
           <Route path="estimate" element={<Estimate />} />
         </Route>
-        <Route path="/tracking" element={<Tracking />} />
-        <Route path="/tracking/detail" element={<TrackingDetail />} />
+        <Route path="/tracking">
+          <Route index element={<Tracking />} />
+          <Route path="detail/:historyId" element={<TrackingDetail />} />
+        </Route>
       </Route>
     </Routes>
   );

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,19 +1,17 @@
-import { Outlet, Route, Routes } from 'react-router-dom';
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
 
 import { Layout } from '@/layouts/Layout';
 import { Estimate } from '@/pages/Estimate';
+import GuestInsurance from '@/pages/Insurance/GuestInsurance';
+import Insurance from '@/pages/Insurance/Insurance';
+import Order from '@/pages/Order';
+import OrderDetail from '@/pages/Order/OrderDetail';
 import { Tracking } from '@/pages/Tracking';
 import { TrackingDetail } from '@/pages/TrackingDetail';
-
-import GuestInsurance from './pages/Insurance/GuestInsurance';
-import Insurance from './pages/Insurance/Insurance';
-import Order from './pages/Order';
-import OrderDetail from './pages/Order/OrderDetail';
 
 export const Router = () => {
   return (
     <Routes>
-      <Route path="/test" element={<Layout />}></Route>
       <Route element={<Layout />}>
         <Route path="/insurance" element={<Outlet />}>
           <Route index element={<Insurance />} />
@@ -28,6 +26,7 @@ export const Router = () => {
           <Route index element={<Tracking />} />
           <Route path="detail/:historyId" element={<TrackingDetail />} />
         </Route>
+        <Route path="*" element={<Navigate to="/tracking" />} />
       </Route>
     </Routes>
   );

--- a/src/services/trackingApi.ts
+++ b/src/services/trackingApi.ts
@@ -35,7 +35,7 @@ export const patchDeliveryStatus = async ({
   const response = await fetch(
     `${BASE_URL}/api/delivery/details?order_history_id=${historyId}&status=${status}`,
     {
-      method: 'patch',
+      method: 'PATCH',
     },
   );
 

--- a/src/services/trackingApi.ts
+++ b/src/services/trackingApi.ts
@@ -1,0 +1,15 @@
+import { BASE_URL, USER_ID } from '@/services';
+import { GetTrackingData } from '@/types';
+
+export const getTracking = async (month: number, status: string) => {
+  const response = await fetch(
+    `${BASE_URL}/api/histories?user_id=${USER_ID}&month=${month}&order_status=${status}`,
+  );
+
+  if (!response.ok) {
+    throw Error('Failed to fetch tracking data');
+  }
+
+  const data = (await response.json()) as { data: GetTrackingData };
+  return data.data;
+};

--- a/src/services/trackingApi.ts
+++ b/src/services/trackingApi.ts
@@ -1,5 +1,5 @@
 import { BASE_URL, USER_ID } from '@/services';
-import { GetTrackingData } from '@/types';
+import { GetTrackingData, GetTrackingDetailData } from '@/types';
 
 export const getTracking = async (month: number, status: string) => {
   const response = await fetch(
@@ -11,5 +11,16 @@ export const getTracking = async (month: number, status: string) => {
   }
 
   const data = (await response.json()) as { data: GetTrackingData };
+  return data.data;
+};
+
+export const getTrackingDetail = async (historyId: number) => {
+  const response = await fetch(`${BASE_URL}/api/delivery/details/${historyId}`);
+
+  if (!response.ok) {
+    throw Error('Failed to fetch tracking detail data');
+  }
+
+  const data = (await response.json()) as { data: GetTrackingDetailData };
   return data.data;
 };

--- a/src/services/trackingApi.ts
+++ b/src/services/trackingApi.ts
@@ -24,3 +24,25 @@ export const getTrackingDetail = async (historyId: number) => {
   const data = (await response.json()) as { data: GetTrackingDetailData };
   return data.data;
 };
+
+export const patchDeliveryStatus = async ({
+  historyId,
+  status,
+}: {
+  historyId: number;
+  status: string;
+}) => {
+  const response = await fetch(
+    `${BASE_URL}/api/delivery/details?order_history_id=${historyId}&status=${status}`,
+    {
+      method: 'patch',
+    },
+  );
+
+  if (!response.ok) {
+    throw Error('Failed to update delivery status data');
+  }
+
+  const data = (await response.json()) as { data: { deliveryDetailStatus: string } };
+  return data.data;
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -124,21 +124,25 @@ export interface PastDates {
   date: string;
 }
 
+export interface SellerInfos {
+  deliveryCompany: string;
+  deliveryTel: string;
+  invoiceNumber: string;
+  seller: string;
+}
+
+export interface BuyerInfos {
+  name: string;
+  tel: string;
+  address: string;
+}
+
 export interface GetTrackingDetailData {
   orderDate: string;
   estimateDate: string;
   currentStatus: string;
   pastDates: PastDates[];
   productInfos: ProductInfos;
-  sellerInfos: {
-    deliveryCompany: string;
-    deliveryTel: string;
-    invoiceNumber: string;
-    seller: string;
-  };
-  buyerInfos: {
-    name: string;
-    tel: string;
-    address: string;
-  };
+  sellerInfos: SellerInfos;
+  buyerInfos: BuyerInfos;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,15 +1,3 @@
-export interface OrderListData {
-  date: string;
-  items: {
-    image: string;
-    title: string;
-    subTitle: string;
-    count: number;
-    state: string;
-    price: number;
-  }[];
-}
-
 export interface InsuranceDataContent {
   [kind: string]: string[];
 }
@@ -101,12 +89,12 @@ export interface GetEstimateData {
   sumPrice: number;
 }
 
-export interface OrderStatuses {
+export interface OrderStatus {
   amount: number;
   statusName: string;
 }
 
-interface OrderHistories {
+export interface OrderHistory {
   id: number;
   category: string;
   name: string;
@@ -119,6 +107,6 @@ interface OrderHistories {
 
 export interface GetTrackingData {
   sumPrice: number;
-  orderStatuses: OrderStatuses[];
-  orderHistories: OrderHistories[];
+  orderStatuses: OrderStatus[];
+  orderHistories: OrderHistory[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -119,24 +119,16 @@ export interface ProductInfos {
   productImage: string;
 }
 
+export interface PastDates {
+  status: string;
+  date: string;
+}
+
 export interface GetTrackingDetailData {
   orderDate: string;
   estimateDate: string;
   currentStatus: string;
-  pastDates: [
-    {
-      status: string;
-      date: string;
-    },
-    {
-      status: string;
-      date: string;
-    },
-    {
-      status: string;
-      date: string;
-    },
-  ];
+  pastDates: PastDates[];
   productInfos: ProductInfos;
   sellerInfos: {
     deliveryCompany: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -110,3 +110,43 @@ export interface GetTrackingData {
   orderStatuses: OrderStatus[];
   orderHistories: OrderHistory[];
 }
+
+export interface ProductInfos {
+  category: string;
+  name: string;
+  salePrice: number;
+  amount: number;
+  productImage: string;
+}
+
+export interface GetTrackingDetailData {
+  orderDate: string;
+  estimateDate: string;
+  currentStatus: string;
+  pastDates: [
+    {
+      status: string;
+      date: string;
+    },
+    {
+      status: string;
+      date: string;
+    },
+    {
+      status: string;
+      date: string;
+    },
+  ];
+  productInfos: ProductInfos;
+  sellerInfos: {
+    deliveryCompany: string;
+    deliveryTel: string;
+    invoiceNumber: string;
+    seller: string;
+  };
+  buyerInfos: {
+    name: string;
+    tel: string;
+    address: string;
+  };
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -100,3 +100,25 @@ export interface GetEstimateData {
   }[];
   sumPrice: number;
 }
+
+export interface OrderStatuses {
+  amount: number;
+  statusName: string;
+}
+
+interface OrderHistories {
+  id: number;
+  category: string;
+  name: string;
+  salePrice: number;
+  amount: number;
+  orderDate: string;
+  productImage: string;
+  status: string;
+}
+
+export interface GetTrackingData {
+  sumPrice: number;
+  orderStatuses: OrderStatuses[];
+  orderHistories: OrderHistories[];
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2021",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
## 요약(Summary)

- 주문/배송 페이지 API를 연동했습니다.
- resolved #20 

## 변경 사항(Changes)

- 하루 사이 안보이던 뷰가 생겨서 매우 당황했지만 바로 퍼블리싱 해서 API 연동했습니다!
  - 택배사, 구매자 정보 컴포넌트
  - 교환, 반품 선택 모달창
- 주문/배송 페이지에서 결제 예정일 전, 후 텍스트가 다르게 보이도록 했습니다. (결제 예정일, 결제 완료일 이런거)

## 리뷰 요구사항

## 확인 방법 (선택)
